### PR TITLE
Solving reuse compliance issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SAP Commerce Cloud, Open Payment Framework
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP-samples/open-payment-framework-integration)](https://api.reuse.software/info/github.com/SAP-samples/open-payment-framework-integration)
 
 ## Overview
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,19 +6,12 @@ SPDX-PackageComment = "The code in this project may include calls to APIs (\"API
 
 [[annotations]]
 path = "postman"
-path = "samples/react-storefront"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 SAP SE or an SAP affiliate company and Open Payment Framework contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "<THIRD-PARTY-FILE-OR-FOLDER-LIST>"
+path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "<COPYRIGHT-OF-THIRD-PARTY-CODE>"
-SPDX-License-Identifier = "<LICENSE-OF-THIRD-PARTY-CODE>"
-
-[[annotations]]
-path = "<ANOTHER-THIRD-PARTY-FILE-OR-FOLDER-LIST>"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "<COPYRIGHT-OF-ANOTHER-THIRD-PARTY-CODE>"
-SPDX-License-Identifier = "<LICENSE-OF-ANOTHER- THIRD-PARTY-CODE>"
+SPDX-FileCopyrightText = "2025 SAP SE or an SAP affiliate company and Open Payment Framework contributors"
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
The issue in the TOML file was the variable `path` was reused and the template TOML was not updated properly to fit all the files which are used in the repository for more on the same please check out: https://reuse.software/spec-3.3/#reusetoml